### PR TITLE
feat: use defopt instead of click for parsing

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,13 +6,13 @@ channels:
 dependencies:
   - biopython=1.78
   - bokeh=2.4.1
-  - click=7.1.2
   - curl
+  - defopt=6.4.0
   - blast=2.10.1
   - diamond=2.0.13
   - numpy=1.21.5
   - pandas=1.3.5
-  - python=3.7
+  - python=3.8
   - ripgrep=13.0.0
   - streamlit=1.8.1
   - tabulate=0.8.9

--- a/plannotate/pLannotate.py
+++ b/plannotate/pLannotate.py
@@ -87,7 +87,7 @@ def batch(*,
           html: bool = True,
           csv: bool = True,
           detailed: bool = True,
-          no_gbk: bool = True) -> None:
+          gbk: bool = False) -> None:
     """
     Annotates engineered DNA sequences, primarily plasmids. Accepts a FASTA or GenBank file and outputs
     a GenBank file with annotations, as well as an optional interactive plasmid map as an HTLM file.
@@ -102,7 +102,7 @@ def batch(*,
         html: creates an html plasmid map in specified path
         csv: creates a cvs file in specified path
         detailed: uses modified algorithm for a more-detailed search with more false positives
-        no_gbk: supresses GenBank output file
+        gkb: output a GenBank file
     """
     if not rsc.databases_exist():
         print("Databases not downloaded. Run 'plannotate setupdb' to download databases.")
@@ -117,10 +117,10 @@ def batch(*,
 
     recordDf = annotate(inSeq, yaml_file, linear, detailed)
 
-    if no_gbk == False:
-        gbk = rsc.get_gbk(recordDf, inSeq, linear)
+    if gbk:
+        gbk_rec = rsc.get_gbk(recordDf, inSeq, linear)
         with open(f"{output}/{file_name}{suffix}.gbk", "w") as handle:
-            handle.write(gbk)
+            handle.write(gbk_rec)
 
     if html:
         bokeh_chart = get_bokeh(recordDf, linear)

--- a/plannotate/pLannotate.py
+++ b/plannotate/pLannotate.py
@@ -142,7 +142,7 @@ def main(argv: List[str] = sys.argv[1:]) -> None:
         yaml,
     ]
     if len(argv) != 0 and all(arg not in argv for arg in ["-h", "--help"]):
-        print("Running command: client-tools " + " ".join(argv))
+        print("Running command: plannotate" + " ".join(argv))
     try:
         defopt.run(funcs=tools, argv=argv)
         print("Completed successfully.")

--- a/plannotate/pLannotate.py
+++ b/plannotate/pLannotate.py
@@ -142,7 +142,7 @@ def main(argv: List[str] = sys.argv[1:]) -> None:
         yaml,
     ]
     if len(argv) != 0 and all(arg not in argv for arg in ["-h", "--help"]):
-        print("Running command: plannotate" + " ".join(argv))
+        print("Running command: plannotate " + " ".join(argv))
     try:
         defopt.run(funcs=tools, argv=argv)
         print("Completed successfully.")


### PR DESCRIPTION
Note: defopt is very opinionated on the single and long flag namings, so there is some backwards incompatibility (e.g. `--file-name` versus `--file_name`).